### PR TITLE
Fix unresolved reference in TaskToolWindowFactory

### DIFF
--- a/src/main/kotlin/com/github/akhilesh170194/jbplugintasktimer/ui/TaskToolWindowFactory.kt
+++ b/src/main/kotlin/com/github/akhilesh170194/jbplugintasktimer/ui/TaskToolWindowFactory.kt
@@ -111,7 +111,7 @@ class TaskToolWindowFactory : ToolWindowFactory {
                     refresh()
                     val idx = service.tasks.lastIndex
                     if (idx >= 0) {
-                        table.rowSelectionInterval(idx, idx)
+                        table.setRowSelectionInterval(idx, idx)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- use `setRowSelectionInterval` API to highlight newly created tasks

## Testing
- `./gradlew test --no-daemon` *(fails: Downloading Gradle wrapper due to missing network access)*