### PR TITLE
Fix merge regressions in task timer UI

### DIFF
--- a/src/main/kotlin/com/github/akhilesh170194/jbplugintasktimer/ui/dialog/TaskDialog.kt
+++ b/src/main/kotlin/com/github/akhilesh170194/jbplugintasktimer/ui/dialog/TaskDialog.kt
@@ -34,8 +34,8 @@ class TaskDialog(private val task: Task?, private val onOk: (name: String, tag: 
     }
 
     override fun createCenterPanel(): JComponent = panel {
-        row("Task Name:") { nameField(growX) }
-        row("Tag:") { tagField(growX) }
+        row("Task Name:") { nameField() }
+        row("Tag:") { tagField() }
         row { overrideBox() }
         row("Idle Timeout (min):") { idleField() }
         row("Long Task Alert (min):") { longTaskField() }


### PR DESCRIPTION
## Summary
- remove leftover form field references
- keep task creation dialog
- refresh table periodically
- simplify TaskDialog layout

## Testing
- `./gradlew buildPlugin` *(fails: No route to host)*