### PR TITLE
Switch plugin to Java 17 and JUnit5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 21
+          java-version: 17
 
       # Setup Gradle
       - name: Setup Gradle
@@ -105,7 +105,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 21
+          java-version: 17
 
       # Setup Gradle
       - name: Setup Gradle
@@ -159,7 +159,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 21
+          java-version: 17
 
       # Run Qodana inspections
       - name: Qodana - Code Inspection
@@ -190,7 +190,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 21
+          java-version: 17
 
       # Setup Gradle
       - name: Setup Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 21
+          java-version: 17
 
       # Setup Gradle
       - name: Setup Gradle

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 21
+          java-version: 17
 
       # Setup Gradle
       - name: Setup Gradle

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,7 +5,7 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="temurin-21" />
+        <option name="gradleJvm" value="temurin-17" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,5 +3,5 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="temurin-21" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="temurin-17" project-jdk-type="JavaSDK" />
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ version = providers.gradleProperty("pluginVersion").get()
 
 // Set the JVM language level used to build the project.
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(17)
 }
 
 // Configure project's dependencies
@@ -31,8 +31,8 @@ repositories {
 
 // Dependencies are managed with Gradle version catalog - read more: https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog
 dependencies {
-    testImplementation(libs.junit)
-    testImplementation(libs.opentest4j)
+    testImplementation(libs.junitJupiterApi)
+    testRuntimeOnly(libs.junitJupiterEngine)
 
     // IntelliJ Platform Gradle Plugin Dependencies Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html
     intellijPlatform {
@@ -128,6 +128,10 @@ kover {
 tasks {
     wrapper {
         gradleVersion = providers.gradleProperty("gradleVersion").get()
+    }
+
+    test {
+        useJUnitPlatform()
     }
 
     publishPlugin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ pluginRepositoryUrl=https://github.com/Akhilesh170194/jb-plugin-task-timer
 # SemVer format -> https://semver.org
 pluginVersion=0.0.1
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild=242
+pluginSinceBuild=233
 pluginUntilBuild=252.*
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType=IC

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # libraries
-junit = "4.13.2"
+junitJupiter = "5.10.2"
 opentest4j = "1.3.0"
 
 # plugins
@@ -11,7 +11,8 @@ kover = "0.9.1"
 qodana = "2025.1.1"
 
 [libraries]
-junit = { group = "junit", name = "junit", version.ref = "junit" }
+junitJupiterApi = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junitJupiter" }
+junitJupiterEngine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junitJupiter" }
 opentest4j = { group = "org.opentest4j", name = "opentest4j", version.ref = "opentest4j" }
 
 [plugins]

--- a/qodana.yml
+++ b/qodana.yml
@@ -3,7 +3,7 @@
 
 version: "1.0"
 linter: jetbrains/qodana-jvm-community:2024.3
-projectJDK: "21"
+projectJDK: "17"
 profile:
   name: qodana.recommended
 exclude:

--- a/src/test/kotlin/com/github/akhilesh170194/jbplugintasktimer/TaskManagerServiceTest.kt
+++ b/src/test/kotlin/com/github/akhilesh170194/jbplugintasktimer/TaskManagerServiceTest.kt
@@ -4,8 +4,10 @@ import com.github.akhilesh170194.jbplugintasktimer.model.TaskStatus
 import com.github.akhilesh170194.jbplugintasktimer.services.TaskManagerService
 import com.intellij.openapi.components.service
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.junit.jupiter.api.Test
 
 class TaskManagerServiceTest : BasePlatformTestCase() {
+    @Test
     fun testTaskLifecycle() {
         val service = project.service<TaskManagerService>()
         val task = service.createTask("sample", "tag", null, null)
@@ -32,6 +34,7 @@ class TaskManagerServiceTest : BasePlatformTestCase() {
         assertTrue(task.sessions.all { it.end != null })
     }
 
+    @Test
     fun testExportFunctions() {
         val service = project.service<TaskManagerService>()
         val task = service.createTask("export", null, null, null)
@@ -50,6 +53,7 @@ class TaskManagerServiceTest : BasePlatformTestCase() {
         assertTrue(jsonContent.startsWith("["))
     }
 
+    @Test
     fun testTaskWithOverrides() {
         val service = project.service<TaskManagerService>()
         val idleTimeout = 10L


### PR DESCRIPTION
## Summary
- update Kotlin toolchain to Java 17
- migrate tests to JUnit5 and enable JUnit Platform
- declare JUnit5 dependencies
- widen IDE compatibility
- adjust CI workflows and project config for JDK 17

## Testing
- `./gradlew test` *(fails: No route to host)*