### PR TITLE
Fix table controls and column widths

### DIFF
--- a/src/main/kotlin/com/github/akhilesh170194/jbplugintasktimer/services/TaskManagerService.kt
+++ b/src/main/kotlin/com/github/akhilesh170194/jbplugintasktimer/services/TaskManagerService.kt
@@ -112,6 +112,12 @@ class TaskManagerService : SerializablePersistentStateComponent<TaskManagerServi
         }
     }
 
+    fun deleteTask(task: Task) {
+        if (tasks.remove(task)) {
+            logChange(task, "Deleted", "")
+        }
+    }
+
     /**
      * Export the current list of tasks to a CSV file.
      */

--- a/src/test/kotlin/com/github/akhilesh170194/jbplugintasktimer/TaskManagerServiceTest.kt
+++ b/src/test/kotlin/com/github/akhilesh170194/jbplugintasktimer/TaskManagerServiceTest.kt
@@ -103,4 +103,17 @@ class TaskManagerServiceTest {
         assertEquals(auditLogEntry.details, deserializedState.auditLogs[0].details)
     }
 
+    @Test
+    fun testDeleteTask() {
+        val task = service.createTask("toDelete", null, null, null)
+        assertTrue(service.tasks.contains(task))
+
+        service.deleteTask(task)
+
+        assertFalse(service.tasks.contains(task))
+        val log = service.auditLogs.last()
+        assertEquals("Deleted", log.action)
+        assertEquals(task.id, log.taskId)
+    }
+
 }


### PR DESCRIPTION
## Summary
- allow editing of Actions column and size task table columns
- stop cell editing before performing actions
- add deleteTask API with audit logging
- exercise deletion logic in tests

## Testing
- `./gradlew test --no-daemon` *(fails: No route to host)*